### PR TITLE
Displays full name with username in competition views

### DIFF
--- a/src/competition/api/handlers.py
+++ b/src/competition/api/handlers.py
@@ -1,0 +1,27 @@
+from django.contrib.auth.models import User
+from django.shortcuts import get_object_or_404
+
+from piston.handler import BaseHandler
+
+from competition.models.team_model import Team
+from competition.models.competition_model import Competition
+from competition.utility import competitor_search_filter 
+
+import re
+
+class CompetitiorHandler(BaseHandler):
+    allowed_methods = ('GET',)
+    model = User
+    fields = ('username','first_name','last_name','get_full_name')
+    
+    def read(self, request, search=None, comp_slug=None, free=False):
+        users = User.objects
+        if comp_slug != None:
+            c = get_object_or_404(Competition,slug=comp_slug)
+            users = users.filter(registration__competition=c)
+            if free:
+                users = users.exclude(team__competition=c)
+        users = users.filter(registration__active=True)
+        if search != None:
+            users = competitor_search_filter(users,search)
+        return users

--- a/src/competition/api/urls.py
+++ b/src/competition/api/urls.py
@@ -1,0 +1,21 @@
+from django.conf.urls.defaults import *
+from piston.resource import Resource
+from competition.api.handlers import CompetitiorHandler
+
+competitor_handler = Resource(CompetitiorHandler)
+
+urlpatterns = patterns('',
+   url(r'^competitors/(?P<comp_slug>[\w-]+)/$', competitor_handler, 
+        name='api-competition-competitors'),
+   url(r'^competitors/(?P<comp_slug>[\w-]+)/free/$', competitor_handler,
+        kwargs=dict(free=True), name='api-competition-freeagents'),
+   url(r'^competitors/(?P<comp_slug>[\w-]+)/(?P<search>[\w ]+)/$',
+        competitor_handler, name='api-competition-competitors-search'),
+   url(r'^competitors/(?P<comp_slug>[\w-]+)/free/(?P<search>[\w ]+)/$', 
+        competitor_handler, kwargs=dict(free=True), 
+        name='api-competition-freeagents-search'),
+   url(r'^competitors/(?P<search>[\w ]+)/$', competitor_handler,
+        name='api-competitors-search'),
+   url(r'^competitors/$', competitor_handler,
+        name='api-competitors'),
+)

--- a/src/competition/templates/competition/team/_team_detail.html
+++ b/src/competition/templates/competition/team/_team_detail.html
@@ -1,3 +1,5 @@
+{% load competition_tags %}
+
 <div class="row-fluid">
   <div class="span{% if team.avatar %}9{% else %}12{% endif %}">
     <div class="well">
@@ -11,7 +13,7 @@
             {% for member in team.members.all %}
               <li>
                 <a href="{{ member.get_absolute_url }}">
-                  {{ member }}
+                    {% competitor_name member %}
                 </a>
               </li>
             {% endfor %}

--- a/src/competition/templates/competition/team/freeagent_list.html
+++ b/src/competition/templates/competition/team/freeagent_list.html
@@ -1,4 +1,5 @@
 {% extends "competition/competition_base.html" %}
+{% load competition_tags %}
 
 {% block content %}
   <h2>Free Agents</h2>
@@ -11,13 +12,7 @@
     {% for user in users %}
       <li>
         <a href="{{ user.get_absolute_url }}">
-          {% if user.get_full_name %}
-            {{user.get_full_name}} (
-          {% endif %}    
-          {{ user.username }}
-          {% if user.get_full_name %}
-            )
-          {% endif %}    
+          {% competitor_name user %}
         </a>
       </li>
     {% empty %}

--- a/src/competition/templates/competition/team/freeagent_list.html
+++ b/src/competition/templates/competition/team/freeagent_list.html
@@ -2,10 +2,10 @@
 
 {% block content %}
   <h2>Free Agents</h2>
-  <form class="form-inline">
+  <form class="form-inline" method="GET" autocomplete="off">
     <label>Search:</label>
-    <input type="text" data-provide="typeahead">
-    <input type="submit" name="submit" value="Submit">
+    <input type="text" name="search" value="{{request.GET.search}}" class="competitor-typeahead">
+    <input type="submit" value="Submit" class='btn'>
   </form>
   <ul class="nav nav-tabs nav-stacked">
     {% for user in users %}
@@ -21,9 +21,31 @@
         </a>
       </li>
     {% empty %}
-      <h3 class="text-center">No free agents</h3>
+      {% if request.GET.search %}
+        <h3 class="text-center">No search results</h3>
+      {% else %}
+        <h3 class="text-center">No free agents</h3>
+      {% endif %}
     {% endfor %}
   </ul>
 
 {% include "competition/_paginator.html" with page=page_obj %}
+{% endblock %}
+
+{% block script %}
+<script>
+function search_free_agents(query,process)
+{
+    var url = "{% url api-competition-freeagents competition.slug %}"+query+"/";
+    $.getJSON(url, function(data)
+    {
+        var items = [];
+        $.each(data, function(key) {
+            items.push(this.get_full_name+' ('+this.username+')');
+        });
+        process(items);
+    });
+}
+$('.competitor-typeahead').typeahead({source: search_free_agents});
+</script>
 {% endblock %}

--- a/src/competition/templates/competition/team/freeagent_list.html
+++ b/src/competition/templates/competition/team/freeagent_list.html
@@ -2,11 +2,22 @@
 
 {% block content %}
   <h2>Free Agents</h2>
+  <form class="form-inline">
+    <label>Search:</label>
+    <input type="text" data-provide="typeahead">
+    <input type="submit" name="submit" value="Submit">
+  </form>
   <ul class="nav nav-tabs nav-stacked">
     {% for user in users %}
       <li>
         <a href="{{ user.get_absolute_url }}">
+          {% if user.get_full_name %}
+            {{user.get_full_name}} (
+          {% endif %}    
           {{ user.username }}
+          {% if user.get_full_name %}
+            )
+          {% endif %}    
         </a>
       </li>
     {% empty %}

--- a/src/competition/templatetags/competition_tags.py
+++ b/src/competition/templatetags/competition_tags.py
@@ -69,3 +69,9 @@ def get_item(obj, arg):
         return obj[arg]
     except (KeyError, TypeError):
         return ''
+
+@register.simple_tag
+def competitor_name(user):
+    if user.get_full_name():
+        return "{} ({})".format(user.get_full_name(),user.username)
+    return user.username

--- a/src/competition/urls.py
+++ b/src/competition/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls.defaults import patterns, url, include
 
 from competition.views.competition_views import CompetitionListView
 from competition.views.competition_views import CompetitionDetailView
@@ -20,6 +20,10 @@ from competition.views.registration_views import UnregisterView
 
 urlpatterns = patterns(
     "",
+
+    # API interfaces
+    url(r'^competition/api/',
+        include('competition.api.urls')),
 
     # Competition Views
     url(r'^competition/$',

--- a/src/competition/utility.py
+++ b/src/competition/utility.py
@@ -1,0 +1,19 @@
+from django.db.models import Q
+
+def competitor_search_filter(queryset, search):
+    # Split the full name on spaces
+    if search != None:
+        search = search.split(" ")
+    else:
+        search = []
+    def jcq(q1,q2):
+        if q1 == None:
+            return q2
+        return q1|q2        
+    q = None
+    for part in search:
+        q = jcq(q,Q(username__icontains=part))
+        q = jcq(q,Q(first_name__icontains=part))
+        q = jcq(q,Q(last_name__icontains=part))
+    queryset = queryset.filter(q)
+    return queryset

--- a/src/competition/views/team_views.py
+++ b/src/competition/views/team_views.py
@@ -10,6 +10,7 @@ from competition.views.mixins import (CompetitionViewMixin, LoggedInMixin,
                                       CheckAllowedMixin, RequireOpenMixin)
 from competition.forms.team_forms import TeamForm
 
+import re
 
 class FreeAgentListView(UserRegisteredMixin, ListView):
     """Lists all freeagents, provided that the user is logged in"""
@@ -20,10 +21,10 @@ class FreeAgentListView(UserRegisteredMixin, ListView):
     def get_queryset(self):
         """Only list teams participating in self.get_competition()"""
         c = self.get_competition()
+        
         users = User.objects.filter(registration__competition=c,
                                     registration__active=True)
         return users.exclude(team__competition=c)
-
 
 class TeamListView(LoggedInMixin, CompetitionViewMixin, ListView):
     """Lists all teams, provided that the user is logged in"""

--- a/src/competition/views/team_views.py
+++ b/src/competition/views/team_views.py
@@ -9,6 +9,7 @@ from competition.views.mixins import (CompetitionViewMixin, LoggedInMixin,
                                       UserRegisteredMixin, ConfirmationMixin,
                                       CheckAllowedMixin, RequireOpenMixin)
 from competition.forms.team_forms import TeamForm
+from competition.utility import competitor_search_filter 
 
 import re
 
@@ -24,7 +25,16 @@ class FreeAgentListView(UserRegisteredMixin, ListView):
         
         users = User.objects.filter(registration__competition=c,
                                     registration__active=True)
+        if 'search' in self.request.GET:
+            users = competitor_search_filter(users, self.request.GET['search'])
         return users.exclude(team__competition=c)
+
+    def render_to_response(self, *args, **kwargs):
+        queryset = self.get_queryset()
+        if queryset.count() == 1 and 'search' in self.request.GET:
+            return redirect(queryset[0].get_absolute_url())
+        else:
+            return super(FreeAgentListView, self).render_to_response(*args,**kwargs)
 
 class TeamListView(LoggedInMixin, CompetitionViewMixin, ListView):
     """Lists all teams, provided that the user is logged in"""


### PR DESCRIPTION
Fixes siggame/webserver#5.
- Changes the users to be displayed as Full Name (Username) if a fullname is available.
- Added a search box to help people find free agents:
  - Added javascript to the free-agent view to use bootstrap typeahead
  - Added piston views (and urls) to access the competitors which includes api endpoints to list all users, all users for a competition, all free agents for a competition, and search views for each.
  - Added an overload to the CBV to redirect to only result if search results in only one competitor.
  - Created a utility.py for the functions generating the filter for the user set.
- Added a template tag to do the display name for this feature and used it
